### PR TITLE
UMD release selection.

### DIFF
--- a/docs/args.rst
+++ b/docs/args.rst
@@ -14,16 +14,14 @@ Runtime arguments are given through `fab` argument list. Currently supported
 runtime arguments are:
 
 
-:installation_type: Type of installation.
+:umd_release: UMD release to be triggered.
 
                 - Available options:
+                    :3: UMD-3 release.
+                    :4: UMD-4 release.
 
-                    :install: from scratch installation, launches
-                        `QC_DIST_1 <http://egi-qc.github.io/#INSTALLATION>`_.
-                    :update: update from last production version, launches
-                        `QC_UPGRADE_1 <http://egi-qc.github.io/#INSTALLATION>`_.
-
-                - Default value: ``install``
+                - Default value: No default value, this parameter **is required**
+                  to be provided at runtime.
 
 :repository_url: Repository path with the verification content.
 
@@ -37,12 +35,16 @@ runtime arguments are:
 
                 - Arguments passed with equal names will overwrite the value.
 
-:umd_release: Package URL with the UMD release.
+:installation_type: Type of installation.
 
-                - Value must contain a URL pointing to a valid UMD release
-                  package.
-                - **Required** value located in the default
-                  configuration file (see :ref:`static-args-ref`).
+                - Available options:
+
+                    :install: from scratch installation, launches
+                        `QC_DIST_1 <http://egi-qc.github.io/#INSTALLATION>`_.
+                    :update: update from last production version, launches
+                        `QC_UPGRADE_1 <http://egi-qc.github.io/#INSTALLATION>`_.
+
+                - Default value: ``install``
 
 :igtf_repo: Repository for the IGTF release.
 

--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -46,6 +46,9 @@ the format:
 The available runtime arguments are explained in :ref:`runtime-args-ref`
 section.
 
+Note that the only mandaatory parameter that is required at runtime is
+`umd_release`.
+
 
 Creating a new verification
 ---------------------------

--- a/etc/defaults.yaml
+++ b/etc/defaults.yaml
@@ -7,11 +7,14 @@ epel_release:
     centos7: "http://mirror.uv.es/mirror/fedora-epel//epel-release-latest-7.noarch.rpm"
 
 umd_release:
-    redhat5:  "http://repository.egi.eu/sw/production/umd/3/sl5/x86_64/updates/umd-release-3.0.1-1.el5.noarch.rpm"
-    redhat6:  "http://repository.egi.eu/sw/production/umd/3/sl6/x86_64/updates/umd-release-3.0.1-1.el6.noarch.rpm"
-    debian6:  "http://repository.egi.eu/sw/production/umd/3/debian/dists/squeeze/main/binary-amd64/umd-release-3.0.0_all.deb" 
-    ubuntu14: "http://repository.egi.eu/sw/production/umd/3/debian/dists/squeeze/main/binary-amd64/umd-release-3.0.0_all.deb" 
-    centos7:  "http://repository.egi.eu/sw/production/umd/4/centos7/x86_64/base/umd-release-4.0.0-1.el7.noarch.rpm" 
+    3:
+        redhat5:  "http://repository.egi.eu/sw/production/umd/3/sl5/x86_64/updates/umd-release-3.0.1-1.el5.noarch.rpm"
+        redhat6:  "http://repository.egi.eu/sw/production/umd/3/sl6/x86_64/updates/umd-release-3.0.1-1.el6.noarch.rpm"
+        debian6:  "http://repository.egi.eu/sw/production/umd/3/debian/dists/squeeze/main/binary-amd64/umd-release-3.0.0_all.deb" 
+    4:
+        #redhat6:
+        #ubuntu14: "http://repository.egi.eu/sw/production/umd/3/debian/dists/squeeze/main/binary-amd64/umd-release-3.0.0_all.deb" 
+        centos7:  "http://repository.egi.eu/sw/production/umd/4/centos7/x86_64/base/umd-release-4.0.0-1.el7.noarch.rpm" 
 
 puppet_release:
     redhat5:  "https://yum.puppetlabs.com/puppetlabs-release-el-5.noarch.rpm" 

--- a/umd/base/installation/__init__.py
+++ b/umd/base/installation/__init__.py
@@ -104,7 +104,7 @@ class Install(object):
         msg_purge = "UMD"
         paths_to_purge = ["%s/UMD-*" % repopath]
         pkgs_to_purge = ["umd-release*"]
-        pkgs_to_download = [("UMD", config.CFG["umd_release"])]
+        pkgs_to_download = [("UMD", config.CFG["umd_release_pkg"])]
         pkgs_additional = []
         if system.distname == "redhat":
             msg_purge = " ".join(["EPEL and/or", msg_purge])
@@ -203,15 +203,17 @@ class Install(object):
     @butils.qcstep("QC_DIST_1", "Binary Distribution")
     def qc_dist_1(self):
         _logfile = "qc_inst_1"
+        repo = config.CFG.get("repository_url", [])
 
         if self.repo_config:
             self._config_repo(logfile=_logfile)
 
         # NOTE(orviz): missing WARNING case
         # 1) Enable verification repository
-        if self.verification_repo_config:
-            for url in config.CFG["repository_url"]:
-                self._enable_verification_repo(url, logfile=_logfile)
+        if repo:
+            if self.verification_repo_config:
+                for url in config.CFG["repository_url"]:
+                    self._enable_verification_repo(url, logfile=_logfile)
 
         # 2) Refresh
         self.pkgtool.refresh()
@@ -223,11 +225,12 @@ class Install(object):
     @butils.qcstep("QC_UPGRADE_1", "Upgrade")
     def qc_upgrade_1(self):
         _logfile = "qc_upgrade_1"
+        repo = config.CFG.get("repository_url", [])
 
         if self.repo_config:
             self._config_repo(logfile=_logfile)
 
-        if config.CFG["repository_url"]:
+        if repo:
             # 1) Install base (production) version
             r = self.pkgtool.install(self.metapkg, log_to_file=_logfile)
             if r.failed:
@@ -241,7 +244,7 @@ class Install(object):
 
             # 2) Enable verification repository
             if self.verification_repo_config:
-                for url in config.CFG["repository_url"]:
+                for url in repo:
                     self._enable_verification_repo(url, logfile=_logfile)
 
             # 3) Refresh

--- a/umd/utils.py
+++ b/umd/utils.py
@@ -454,7 +454,8 @@ class PkgTool(object):
 def show_exec_banner_ascii():
     """Displays execution banner (ascii)."""
     cfg = config.CFG.copy()
-    basic_repo = ["umd_release", "igtf_repo"]
+
+    basic_repo = ["umd_release_pkg", "igtf_repo"]
     if system.distname in ["redhat", "centos"]:
         basic_repo.append("epel_release")
 
@@ -485,10 +486,11 @@ def show_exec_banner_ascii():
                                 colors.blue(v)))
     print(u'\n\n')
 
-    api.info("Using the following verification repositories")
-    repos = to_list(cfg.pop("repository_url"))
-    for repo in repos:
-        print(u'\t+ %s' % colors.blue(repo))
+    if "repository_url" in cfg.keys():
+        api.info("Using the following UMD verification repositories")
+        repos = to_list(cfg.pop("repository_url"))
+        for repo in repos:
+            print(u'\t+ %s' % colors.blue(repo))
 
 
 def show_exec_banner():


### PR DESCRIPTION
umd_release is now the only mandatory parameter. Deployments can
involve verifications or not, so repository_url is no longer a
mandatory input parameter.
